### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/solve_threesixty/api.py
+++ b/solve_threesixty/api.py
@@ -19,7 +19,7 @@ except ImportError:
         """
         Removes empty values from a dict.
         """
-        return dict([(k, v) for k, v in d.items() if v and len(v) > 0])
+        return {k: v for k, v in d.items() if v and len(v) > 0}
 
 logger = logging.getLogger('solve_threesixty')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:amites:python-solve-threesixty?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:amites:python-solve-threesixty?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
